### PR TITLE
Remove emit_within

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,7 +1,7 @@
 [
   inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"],
   line_length: 100,
-  locals_without_parens: [emit_to: 1]
+  locals_without_parens: [emit_to: 1],
   export: [
     locals_without_parens: [emit_to: 1]
   ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,8 @@
 [
   inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"],
-  line_length: 100
+  line_length: 100,
+  locals_without_parens: [emit_to: 1]
+  export: [
+    locals_without_parens: [emit_to: 1]
+  ]
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Removed `Sea.Signal.emit_within/1`
+
 ## 0.2.0
 
 - Revamped documentation

--- a/examples/invoicing_app/.formatter.exs
+++ b/examples/invoicing_app/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  import_deps: [:sea]
 ]

--- a/examples/invoicing_app/lib/invoicing_app/analytics/analytics.ex
+++ b/examples/invoicing_app/lib/invoicing_app/analytics/analytics.ex
@@ -3,9 +3,8 @@ defmodule InvoicingApp.Analytics do
   Analytics system manages data warehousing, bookkeeping and reporting.
   """
 
+  use InvoicingApp.SignalRouter, :single_observer
   alias __MODULE__.GetInvoiceCountService
 
-  def get_invoice_count(customer_id) do
-    GetInvoiceCountService.call(customer_id)
-  end
+  defdelegate get_invoice_count(customer_id), to: GetInvoiceCountService, as: :call
 end

--- a/examples/invoicing_app/lib/invoicing_app/analytics/observer.ex
+++ b/examples/invoicing_app/lib/invoicing_app/analytics/observer.ex
@@ -1,4 +1,4 @@
-defmodule InvoicingApp.Analytics.InvoiceCreatedObserver do
+defmodule InvoicingApp.Analytics.Observer do
   use Sea.Observer
 
   alias InvoicingApp.Repo

--- a/examples/invoicing_app/lib/invoicing_app/customers/customers.ex
+++ b/examples/invoicing_app/lib/invoicing_app/customers/customers.ex
@@ -3,16 +3,9 @@ defmodule InvoicingApp.Customers do
   Customers system manages customers interested in purchasing products.
   """
 
-  alias __MODULE__.{
-    CheckActiveService,
-    RegisterAccountService
-  }
+  use InvoicingApp.SignalRouter, :one_signal_one_observer
+  alias __MODULE__.{CheckActiveService, RegisterAccountService}
 
-  def active?(account_id) do
-    CheckActiveService.call(account_id)
-  end
-
-  def register_account(name) do
-    RegisterAccountService.call(name)
-  end
+  defdelegate active?(account_id), to: CheckActiveService, as: :call
+  defdelegate register_account(name), to: RegisterAccountService, as: :call
 end

--- a/examples/invoicing_app/lib/invoicing_app/inventory/inventory.ex
+++ b/examples/invoicing_app/lib/invoicing_app/inventory/inventory.ex
@@ -3,16 +3,9 @@ defmodule InvoicingApp.Inventory do
   Inventory system manages products and their stock levels.
   """
 
-  alias __MODULE__.{
-    CreateProductService,
-    IncreaseStockService
-  }
+  use InvoicingApp.SignalRouter, :one_signal_one_observer
+  alias __MODULE__.{CreateProductService, IncreaseStockService}
 
-  def create_product do
-    CreateProductService.call()
-  end
-
-  def increase_stock(product_id, amount \\ 1) do
-    IncreaseStockService.call(product_id, amount)
-  end
+  defdelegate create_product, to: CreateProductService, as: :call
+  defdelegate increase_stock(product_id, amount \\ 1), to: IncreaseStockService, as: :call
 end

--- a/examples/invoicing_app/lib/invoicing_app/sales/invoice_created_signal.ex
+++ b/examples/invoicing_app/lib/invoicing_app/sales/invoice_created_signal.ex
@@ -1,7 +1,7 @@
 defmodule InvoicingApp.Sales.InvoiceCreatedSignal do
   use Sea.Signal
 
-  emit_within(InvoicingApp.{Analytics, Customers, Inventory})
+  emit_to InvoicingApp.{Analytics, Customers, Inventory}
 
   defstruct [:customer_id, :product_id]
 

--- a/examples/invoicing_app/lib/invoicing_app/signal_router.ex
+++ b/examples/invoicing_app/lib/invoicing_app/signal_router.ex
@@ -1,0 +1,46 @@
+defmodule InvoicingApp.SignalRouter do
+  @moduledoc """
+  Defines project-wide convention for routing Sea signals to nested observers.
+
+  This module is completely optional but serves as a working example as to how to route signals sent
+  to root-level module deeper into observers within it. This way we can write `emit_to
+  InvoicingApp.Inventory` instead of `emit_to InvoicingApp.Inventory.InvoiceCreatedObserver` which
+  yields benefits described in the *Organizing observers* guide.
+  """
+
+  @doc """
+  Routes incoming signals to nested observer (single one for all incoming signals).
+  """
+  def single_observer do
+    quote do
+      use Sea.Observer
+
+      @impl true
+      def handle_signal(signal) do
+        __MODULE__.Observer.handle_signal(signal)
+      end
+    end
+  end
+
+  @doc """
+  Routes incoming signals to nested observers (separate ones for each incoming signal).
+  """
+  def one_signal_one_observer do
+    quote do
+      use Sea.Observer
+
+      @impl true
+      def handle_signal(signal = %{__struct__: signal_mod}) do
+        signal_name = signal_mod |> Module.split() |> List.last()
+        observer_name = String.replace(signal_name, ~r/Signal$/, "Observer")
+        observer_mod = :"#{__MODULE__}.#{observer_name}"
+
+        observer_mod.handle_signal(signal)
+      end
+    end
+  end
+
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, [])
+  end
+end

--- a/guides/decoupling_contexts.md
+++ b/guides/decoupling_contexts.md
@@ -44,7 +44,7 @@ Let's start by introducing a signal capable of building itself from our invoice 
     defmodule InvoicingApp.Sales.InvoiceCreatedSignal do
       use Sea.Signal
 
-      emit_within InvoicingApp.{Analytics, Customers, Inventory}
+      emit_to InvoicingApp.{Analytics, Customers, Inventory}
 
       defstruct [:customer_id, :product_id]
 

--- a/guides/organizing_observers.md
+++ b/guides/organizing_observers.md
@@ -1,12 +1,14 @@
 # Organizing observers
 
 You can organize your signals and observers in any way you like and link them freely with
-`Sea.Signal.emit_to/1` macro calls.
+`Sea.Signal.emit_to/1` macro calls. Sea doesn't limit you in this regard as it'll depend on specific
+use cases how best to name and split observers mapped to the signals. In this guide, we'll review
+some of possible approaches and propose technical solutions for applying them efficiently.
 
 For instance, you could choose to share observer logic for handling multiple signals by implementing
-single observer module with multiple `c:Sea.Observer.handle_signal/1` clauses, target it from multiple
-signals and pattern-match specific signal or group of signals there. The `AnalyticsObserver` from
-the [basic example] could become such multi-signal observer, ie:
+single observer module with multiple `c:Sea.Observer.handle_signal/1` clauses, target it from
+multiple signals and pattern-match specific signal or group of signals there. The
+`AnalyticsObserver` from the [basic example] could become such multi-signal observer, ie:
 
     defmodule AnalyticsObserver do
       use Sea.Observer
@@ -28,24 +30,106 @@ the [basic example] could become such multi-signal observer, ie:
       end
     end
 
-In a more complex application with multiple contexts you may choose to map signal and observer names
-across context modules in order to simplify working with a growing number of signals and their
-observers scattered across project modules. This may be simplified and made consistent by using the
-`Sea.Signal.emit_within/1` macro:
+This approach was applied in exemplary [`InvoicingApp.Analytics.Observer`] module.
 
-    defmodule InvoicingApp.Sales.InvoiceCreatedSignal do
+An opposite approach would be to implement observers dedicated to specific signals and perhaps map
+signal and observer names across context modules in order to simplify working with a growing number
+of signals and observers scattered across project modules, ie:
+
+    defmodule InvocingApp.Sales.InvoiceCreatedSignal do
       use Sea.Signal
 
-      emit_within InvoicingApp.{Analytics, Customers}
-      # ...is equivalent to more explicit:
-      # emit_to InvoicingApp.Analytics.InvoiceCreatedObserver
-      # emit_to InvoicingApp.Customers.InvoiceCreatedObserver
+      emit_to InvocingApp.Customers.InvoiceCreatedObserver
+      emit_to InvocingApp.Inventory.InvoiceCreatedObserver
 
-      defstruct [:invoice_number, customer_id]
+      # ...
     end
 
-In such case, Sea will take the original signal name and replace the `Signal` suffix with `Observer`
-suffix to infer the name of observer module within specific parent (context) module. This should
-keep the entire codebase that sticks to `emit_within` consistent and predictable.
+    defmodule InvocingApp.Customers.InvoiceCreatedObserver do
+      use Sea.Observer
+
+      # ...
+    end
+
+    defmodule InvocingApp.Inventory.InvoiceCreatedObserver do
+      use Sea.Observer
+
+      # ...
+    end
+
+This is indeed how exemplary [`InvoicingApp.Customers.InvoiceCreatedObserver`] and
+[`InvoicingApp.Inventory.InvoiceCreatedObserver`] were organized.
+
+Regardless of the approach, you may want to avoid a fishy practice from the above example - forcing
+signals nested in `InvoicingApp.Sales` module to pick specific observer modules internal to
+`InvoicingApp.Customers` or `InvoicingApp.Inventory` - they should be a private implementation
+detail of these modules. This can be achieved by delegating `handle_signal` from entry module to one
+of its nested observers. For the "single observer" approach, this could be as simple as:
+
+    def InvoicingApp.Analytics do
+      use Sea.Observer
+
+      defdelegate handle_signal(signal), to: __MODULE__.Observer
+    end
+
+For "one signal one observer" approach we could pick observer dynamically based on signal name:
+
+    def InvoicingApp.Customers do
+      use Sea.Observer
+
+      @impl true
+      def handle_signal(signal = %{__struct__: signal_mod}) do
+        signal_name = signal_mod |> Module.split() |> List.last()
+        observer_name = String.replace(signal_name, ~r/Signal$/, "Observer")
+        observer_mod = :"#{__MODULE__}.#{observer_name}"
+
+        observer_mod.handle_signal(signal)
+      end
+    end
+
+Here, the original signal name was taken and the `Signal` suffix was replaced with `Observer` suffix
+in order to infer the name of child observer module within specific entry module.
+
+Finally, you could put one (or both) of these observer organization strategies into reusable module
+that you would subsequently `use` in all entry modules that include observers. You can find a sample
+working implementation of such solution in the [`InvoicingApp.SignalRouter`] module:
+
+    defmodule InvoicingApp.SignalRouter do
+      def single_observer do
+        quote do
+          # handle_signal delegate presented above for InvoicingApp.Analytics
+        end
+      end
+
+      def one_signal_one_observer do
+        quote do
+          # handle_signal router presented above for InvoicingApp.Customers
+        end
+      end
+
+      defmacro __using__(which) when is_atom(which) do
+        apply(__MODULE__, which, [])
+      end
+    end
+
+    def InvoicingApp.Analytics do
+      use InvoicingApp.SignalRouter, :single_observer
+    end
+
+    def InvoicingApp.Customers do
+      use InvoicingApp.SignalRouter, :one_signal_one_observer
+    end
+
+    def InvoicingApp.Inventory do
+      use InvoicingApp.SignalRouter, :one_signal_one_observer
+    end
+
+This way all of your observers will be organized in consistent and predictable way, with a single
+module that describes the rules governing this aspect of your application and with explicit yet
+compact references to it all over the project.
 
 [Basic example]: basic_example.html
+[`InvoicingApp.Analytics.Observer`]: https://github.com/surgeventures/sea-elixir/tree/master/examples/invoicing_app/lib/invoicing_app/analytics/observer.ex
+[`InvoicingApp.Customers.InvoiceCreatedObserver`]: https://github.com/surgeventures/sea-elixir/tree/master/examples/invoicing_app/lib/invoicing_app/customers/invoice_created_observer.ex
+[`InvoicingApp.Inventory.InvoiceCreatedObserver`]: https://github.com/surgeventures/sea-elixir/tree/master/examples/invoicing_app/lib/invoicing_app/inventory/invoice_created_observer.ex
+[`InvoicingApp.SignalRouter`]: https://github.com/surgeventures/sea-elixir/tree/master/examples/invoicing_app/lib/invoicing_app/signal_router.ex

--- a/test/sea_test.exs
+++ b/test/sea_test.exs
@@ -10,12 +10,9 @@ defmodule SeaTest do
 
       defstruct [:number_as_string]
 
-      emit_to(SeaTest.Mod1)
-      emit_to(SeaTest.{Mod2, Mod3})
-      emit_to([SeaTest.Mod4, SeaTest.Mod5])
-      emit_within(SeaTest.Mod6)
-      emit_within(SeaTest.{Mod7, Mod8})
-      emit_within([SeaTest.Mod9, SeaTest.ModA])
+      emit_to SeaTest.Mod1
+      emit_to SeaTest.{Mod2, Mod3}
+      emit_to [SeaTest.Mod4, SeaTest.Mod5]
 
       def build(1) do
         %__MODULE__{number_as_string: "one"}
@@ -67,51 +64,6 @@ defmodule SeaTest do
       end
     end
 
-    defmodule Mod6.SampleObserver do
-      use Sea.Observer
-
-      @impl true
-      def handle_signal(%SampleSignal{number_as_string: str}) do
-        IO.puts("Mod6 got #{str}")
-      end
-    end
-
-    defmodule Mod7.SampleObserver do
-      use Sea.Observer
-
-      @impl true
-      def handle_signal(%SampleSignal{number_as_string: str}) do
-        IO.puts("Mod7 got #{str}")
-      end
-    end
-
-    defmodule Mod8.SampleObserver do
-      use Sea.Observer
-
-      @impl true
-      def handle_signal(%SampleSignal{number_as_string: str}) do
-        IO.puts("Mod8 got #{str}")
-      end
-    end
-
-    defmodule Mod9.SampleObserver do
-      use Sea.Observer
-
-      @impl true
-      def handle_signal(%SampleSignal{number_as_string: str}) do
-        IO.puts("Mod9 got #{str}")
-      end
-    end
-
-    defmodule ModA.SampleObserver do
-      use Sea.Observer
-
-      @impl true
-      def handle_signal(%SampleSignal{number_as_string: str}) do
-        IO.puts("ModA got #{str}")
-      end
-    end
-
     assert capture_io(fn ->
              SampleSignal.emit(1)
            end) == """
@@ -120,11 +72,6 @@ defmodule SeaTest do
            Mod3 got one
            Mod4 got one
            Mod5 got one
-           Mod6 got one
-           Mod7 got one
-           Mod8 got one
-           Mod9 got one
-           ModA got one
            """
   end
 
@@ -134,7 +81,7 @@ defmodule SeaTest do
 
       defstruct []
 
-      emit_to(SeaTest.MockableObserver)
+      emit_to SeaTest.MockableObserver
 
       def build(:empty), do: %__MODULE__{}
     end


### PR DESCRIPTION
After internal discussion, we've decided that Sea shouldn't concern itself with specific module naming conventions and code organization strategies. It's a thin library and not framework. Also, there's a number of alternative strategies to the one specific picked by prior Sea implementation.

Therefore,`Sea.Signal.emit_within/1` macro was removed from API.

This concern is now handled by rewritten "Organizing observers" guide and `InvoicingApp.SignalRouter` implementation in `examples/invoicing_app` (which was also modified to fully depict the new approach and to stop using the removed API). This proposes a solution for orgazining observers in uniform, convention-driven fashion but by custom-tailored convention defined within specific application, not in Sea.